### PR TITLE
remove default instance-id dimensions field

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -6,7 +6,7 @@ var AWS  = require('aws-sdk'),
 var l, debug, dumpMessages
 var noopLogger = {log: function(){}}
 
-var Backend = module.exports = function(options, time, binder, logger) {
+var Backend = exports.Backend = function(options, time, binder, logger) {
   options = _.defaults(options || {}, {
     client:     new AWS.CloudWatch(),
     dimensions: {},
@@ -68,7 +68,7 @@ function collect_timers(date, timers, dimensions) {
   for (var key in timers) {
     var data = timers[key].length
       ? timers[key] : [0]
-    
+
     var values = {
       Minimum:     _.min(data),
       Maximum:     _.max(data),
@@ -139,7 +139,7 @@ function report_success(metric_params, stats) {
   var s = 'cloudwatch recieved ' +
     counters.length + ' counters, ' +
     timers.length + ' timers, and ' +
-    gauges.length + ' gauges' 
+    gauges.length + ' gauges'
 
    l.log(s)
 }

--- a/lib/init.js
+++ b/lib/init.js
@@ -3,13 +3,13 @@ var AWS  = require('aws-sdk'),
     util = require('util'),
     _    = require('underscore')
 
-var Backend = require('./backend')
+var backend = require('./backend')
 
 exports.init = function(startupTime, config, emitter, logger) {
   config = _.defaults(config.cloudwatch || {}, {
     debug: config.debug,
     dumpMessages: config.dumpMessages,
-    dimensions: { 'InstanceId': '' }
+    dimensions: {}
   })
 
   if (!config.namespace) {
@@ -26,32 +26,35 @@ exports.init = function(startupTime, config, emitter, logger) {
     cloudwatch: '2010-08-01',
   }
 
-  if (config.dimensions['InstanceId'] != '')
-    startup(config, startupTime, emitter, logger)
-  else {
-    var metadata = new AWS.MetadataService()
-    metadata.request('/latest/meta-data/instance-id', function(err, data) {
-      if (err) {
-        if (config.debug)
-          logger.log('cloudwatch backend could not access meta-data service: ' + err.code)
+  // load some meta data information
+  var metadataServce = new AWS.MetadataService()
+  var metadata = {};
+  metadataServce.request('/latest/meta-data/instance-id', function(err, data) {
+    if (err) {
+      if (config.debug)
+        logger.log('cloudwatch backend could not access meta-data service: ' + err.code)
 
-        if (config.dumpMessages)
-          fmt.dump(err)
-      }
+      if (config.dumpMessages)
+        fmt.dump(err)
 
-      if (data) {
-        config.dimensions['InstanceId'] = data
-      }
- 
-      startup(config, startupTime, emitter, logger)
+      return
+    }
+    metadata.InstanceId = data
+
+    // update dimensions with meta data information
+    Object.keys(config.dimensions).forEach(function (key) {
+      var val = config.dimensions[key];
+      config.dimensions[key] = _.template(val)(metadata)
     })
-  }
+
+    startup(config, startupTime, emitter, logger)
+  });
 
   return true
 }
 
 function startup(config, time, emitter, logger) {
-  new Backend(config, time, function(flush, status) {
+  new backend.Backend(config, time, function(flush, status) {
     if (flush) emitter.on('flush', flush)
     if (status) emitter.on('status', status)
   }, logger)

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
   "main": "lib/init.js",
   "dependencies": {
     "fmt": "~0.4",
-    "underscore": "1.4.x",
+    "underscore": "^1.8.3",
     "aws-sdk": "2.0.x"
   },
   "devDependencies": {
     "chai": "~1.4.2",
-    "mocha": "*",
-    "statsd": "^0.7.2"
+    "mocha": "^2.3.4",
+    "statsd": "^0.7.2",
+    "sinon": "^1.17.2"
   },
   "optionalDependencies": {},
   "scripts": {

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -2,7 +2,7 @@ var expect  = require('chai').expect,
     _       = require('underscore'),
     Fixture = require('./fixture'),
     Fake    = require('./fake'),
-    Backend = require('../lib/backend.js')
+    Backend = require('../lib/backend.js').Backend
 
 describe('new backend', function() {
   var backend = new Backend()
@@ -62,7 +62,7 @@ describe('flushing counters', function() {
   var metric = null
   var cloudwatch = new Fake.CloudWatch()
   var backend = new Backend({
-    client: cloudwatch, namespace: 'abc.123', dimensions: { 'InstanceId': 'i-xyz' }
+    client: cloudwatch, namespace: 'abc.123'
   })
 
   beforeEach(function() {
@@ -93,11 +93,9 @@ describe('flushing counters', function() {
     expect(metric.Timestamp.getTime()).to.equal(Fixture.now.getTime())
   })
 
-  it('should send a dimension', function() {
+  it('should not send a dimension', function() {
     var dimensions = metric.Dimensions
-    expect(dimensions).to.have.length(1)
-    expect(dimensions[0]['Name']).to.equal('InstanceId')
-    expect(dimensions[0]['Value']).to.equal('i-xyz')
+    expect(dimensions).to.have.length(0)
   })
 
   it('should not send a statsd counter', function() {

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,0 +1,44 @@
+var expect  = require('chai').expect,
+    sinon   = require('sinon'),
+    AWS     = require('aws-sdk'),
+    init    = require('../lib/init')
+    backend = require('../lib/backend')
+    _       = require('underscore')
+
+describe.only('init', function() {
+  describe('#init', function () {
+    before(function () {
+      sinon.stub(AWS.MetadataService.prototype, 'request')
+      sinon.stub(backend, 'Backend')
+
+      this.ms = AWS.MetadataService.prototype
+      this.emitter = sinon.stub({ on: _.noop })
+      this.logger = sinon.stub({ log: _.noop })
+    })
+
+    beforeEach(function () {
+      this.config = {
+        cloudwatch: {
+          namespace: 'test-namespace',
+          region: 'test-region',
+          dimensions: {
+            InstanceId: '<%= InstanceId %>'
+          }
+        }
+      }
+    })
+
+    after(function () {
+      AWS.MetadataService.prototype.request.restore()
+      backend.Backend.restore()
+    })
+
+    it('should update given dimension fields with found metadata items', function () {
+      this.ms.request.yields(null, 'id-123')
+      init.init(null, this.config, this.emitter, this.logger)
+
+      expect(backend.Backend.called).to.true
+      expect(backend.Backend.getCall(0).args[0].dimensions).to.have.property('InstanceId', 'id-123')
+    })
+  })
+})

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: wercker/nodejs
+box: node:5
 # Build definition
 build:
   # The steps that will be executed on build


### PR DESCRIPTION
This PR makes the dimensions field optional and introduces [underscore.template](http://underscorejs.org/#template) syntax for given dimension fields, so that they can be substituted with real aws-metadata.
