### PR TITLE
add metricsLimit option to limit the amount of outgoing metrics

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -7,8 +7,8 @@ function collectTimers(date, timers, dimensions) {
     const data = timers[key].length ? timers[key] : [0];
 
     const values = {
-      Minimum: _.min(data),
-      Maximum: _.max(data),
+      Minimum: Math.min.apply(null, data),
+      Maximum: Math.max.apply(null, data),
       Sum: data.reduce((memo, num) => memo + num, 0),
       SampleCount: data.length
     };
@@ -48,8 +48,8 @@ function collectGauges(date, gauges, dimensions) {
 }
 
 // true, if there is at least one matching item
-function oneMatch(list, key) {
-  return _.find(list, (regex) => regex.test(key));
+function someMatch(list, key) {
+  return _.some(list, (regex) => regex.test(key));
 }
 
 /**
@@ -62,7 +62,7 @@ function filterMetrics(metrics = {}, options = {}) {
   const blacklist = options.blacklist || [];
 
   Object.keys(metrics).forEach((key) => {
-    if (oneMatch(whitelist, key) && !oneMatch(blacklist, key)) {
+    if (someMatch(whitelist, key) && !someMatch(blacklist, key)) {
       result[key] = metrics[key];
     }
   });
@@ -118,8 +118,9 @@ export class Backend {
       namespace: 'unknown',
       debug: false,
       dumpMessages: false,
-      whitelist: ['.*'],        // default: accept all
-      blacklist: ['statsd\\.']  // default: blacklist statsd internal metrics
+      whitelist: ['.*'],          // default: accept all
+      blacklist: ['statsd\\.'],   // default: blacklist statsd internal metrics
+      limitMetrics: 0             // default: no limit
     });
 
     this.logger = logger || _.noop;
@@ -131,6 +132,8 @@ export class Backend {
     this.dimensions = listDimensions(options.dimensions);
     this.whitelist = options.whitelist.map((item) => new RegExp(item));
     this.blacklist = options.blacklist.map((item) => new RegExp(item));
+    this.metricsLimit = options.metricsLimit;
+    this.uniqMetrics = {};
 
     this.stats = {
       last_flush: time,
@@ -138,12 +141,42 @@ export class Backend {
     };
   }
 
-  flush(time, metrics) {
-    const date = new Date(time * 1000);
+  /**
+   * check the data for unique metrics and limit the amout of sent metrics if the limit is reached
+   */
+  limitData(data) {
+    if (this.metricsLimit === 0) { // we dont want to limit at all
+      return data;
+    }
+
+    let currentSize = Object.keys(this.uniqMetrics).length;
+
+    return data.filter((metric) => {
+      const metricName = metric.MetricName;
+
+      if (this.uniqMetrics[metricName]) {
+        return true;
+      }
+
+      if (currentSize >= this.metricsLimit) {
+        return false;
+      }
+
+      this.uniqMetrics[metricName] = true;
+      currentSize += 1;
+      return true;
+    });
+  }
+
+  flush(timestamp, metrics) {
+    const date = new Date(timestamp * 1000);
     let data = _.union(
       collectTimers(date, filterMetrics(metrics.timers, this), this.dimensions),
       collectCounters(date, filterMetrics(metrics.counters, this), this.dimensions),
       collectGauges(date, filterMetrics(metrics.gauges, this), this.dimensions));
+
+    // limit metrics to not create uncontrolled aws costs
+    data = this.limitData(data);
 
     if (this.debug) {
       this.logger(`cloudwatch - flushing ${data.length} metrics`);
@@ -157,9 +190,11 @@ export class Backend {
 
       const stats = this.stats;
       this.client.putMetricData(params, (err) => {
-        return err ?
-               reportError(err, stats, this.dumpMessages, this.logger) :
-               reportSuccess(params, stats, this.dumpMessages, this.logger);
+        if (err) {
+          return reportError(err, stats, this.dumpMessages, this.logger);
+        }
+
+        return reportSuccess(params, stats, this.dumpMessages, this.logger);
       });
 
       data = data.slice(20);

--- a/lib/init.js
+++ b/lib/init.js
@@ -27,9 +27,6 @@ export function init(startupTime, config, emitter, logger) {
   }
 
   AWS.config.update(config);
-  AWS.config.apiVersions = {
-    cloudwatch: '2010-08-01'
-  };
 
   // load some meta data information
   const metadataServce = new AWS.MetadataService({ httpOptions: { timeout: 10000 } });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "url": "https://github.com/dylanmei/statsd-cloudwatch-backend.git"
   },
   "scripts": {
-    "start": "make start",
+    "build": "rm -rf ./dist && babel -d ./dist ./lib -s",
+    "postinstall": "npm run build",
     "test": "NODE_ENV=test mocha",
     "eslint": "eslint ."
   },

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,15 +1,11 @@
 box: node:5
-# Build definition
 build:
-  # The steps that will be executed on build
   steps:
-    # A step that executes `npm install` command
     - npm-install
-    # A step that executes `npm test` command
     - npm-test
-
-    # A custom script step, name value is used in the UI
-    # and the code value contains the command that get executed
+    - script:
+        name: npm-eslint
+        code: npm run eslint
     - script:
         name: echo nodejs information
         code: |


### PR DESCRIPTION
##### changes
- limit the amount of unique out-going metrics by `metricsLimit`
- add `npm run eslint` step to wercker.yml
